### PR TITLE
Add author block

### DIFF
--- a/src/_data/featured.json
+++ b/src/_data/featured.json
@@ -5,5 +5,7 @@
     "/how-i-almost-died/",
     "/games/",
     "/interviews/",
-    "/books/"
+    "/books/",
+    "/now/",
+    "/uses/"
 ]

--- a/src/_includes/partials/author.html
+++ b/src/_includes/partials/author.html
@@ -1,0 +1,10 @@
+<div class="max-w-screen-lg mx-auto w-full sm:w-3/4 py-4 sm:py-8 bg-gray-50 text-gray-600 shadow-md flex flex-col sm:flex-row justify-center items-center my-4">
+    <div class="w-full sm:w-1/3 flex justify-center">
+        {% image "/images/me/marc-littlemore-512x512.jpg" "Marc Littlemore" 150 "bg-white px-1 py-1 mx-4 my-4 rounded-full w-32 h-32 shadow-lg" %}
+    </div>
+    <div class="w-full sm:w-2/3 text-xl font-medium flex flex-col justify-center space-y-4 px-4 sm:px-0 pt-4 sm:pt-0">
+        <p><strong>I'm Marc Littlemore.</strong> I’m a Software Engineering Manager who loves to help developers to build quality software.</p>
+        <p>I can help you to learn more about software testing and automating your business with chatbots.</p>
+        <p><a href="/about" class="underline hover:text-red-700 text-lg">Find out more</a></p>
+    </div>
+</div>

--- a/src/_includes/partials/author.html
+++ b/src/_includes/partials/author.html
@@ -2,7 +2,7 @@
     <div class="w-full sm:w-1/3 flex justify-center">
         {% image "/images/me/marc-littlemore-512x512.jpg" "Marc Littlemore" 150 "bg-white px-1 py-1 mx-4 my-4 rounded-full w-32 h-32 shadow-lg" %}
     </div>
-    <div class="w-full sm:w-2/3 text-xl font-medium flex flex-col justify-center space-y-4 px-4 sm:px-0 pt-4 sm:pt-0">
+    <div class="w-full sm:w-2/3 text-xl font-medium flex flex-col justify-center space-y-4 px-4 pt-4 sm:pt-0">
         <p><strong>I'm Marc Littlemore.</strong> I’m a Software Engineering Manager who loves to help developers to build quality software.</p>
         <p>I can help you to learn more about software testing and automating your business with chatbots.</p>
         <p><a href="/about" class="underline hover:text-red-700 text-lg">Find out more</a></p>

--- a/src/_includes/partials/pageContent.html
+++ b/src/_includes/partials/pageContent.html
@@ -19,11 +19,15 @@
     </figure>
   </div>
 
-  <section class="pt-4 w-full mx-auto flex flex-col items-center">
+  <section class="py-4 w-full mx-auto flex flex-col items-center">
     <div class="prose prose-xl">
       {{ content }}
     </div>
   </section>
+  
+  {% if tags contains "post" %}
+  {% include partials/author.html %}
+  {% endif %}
 
   {% include partials/webmentions.liquid %}
 </main>

--- a/src/pages/games.md
+++ b/src/pages/games.md
@@ -5,8 +5,6 @@ description: I worked in the video games industry for almost 20 years. I worked 
 permalink: /games/
 headerImage: /images/banners/game-controller.jpg
 date: 2015-02-01
-tags:
-    - post
 ---
 
 I've worked on many projects over the years, both personal and for the companies I've worked for. Here are some of the highlights of my games development career. I've chosen to ignore the many prototypes and cancelled projects I've worked on. Canned projects go with the territory for a game developer!

--- a/src/pages/man-who-nearly-died.md
+++ b/src/pages/man-who-nearly-died.md
@@ -5,8 +5,6 @@ description: In 2014, completely out of the blue, I contracted a bacterial infec
 permalink: /how-i-almost-died/
 headerImage: /images/banners/hospital-lights.jpg
 date: 2015-01-01
-tags:
-    - post
 ---
 
 How do you start to tell someone that you nearly died? That your wife watched you in intensive care, fighting for your life? That your children nearly lost their father when he was only 42?

--- a/src/pages/now.md
+++ b/src/pages/now.md
@@ -5,8 +5,6 @@ description: Inspired by Derek Sivers, this is my now page. It tells you what I'
 permalink: /now/
 headerImage: /images/banners/home-office.jpg
 date: 2015-10-09
-tags:
-    - post
 ---
 
 This page is inspired by Derek Siver's [now page](http://sivers.org/now) suggestion and his [Now Now Now](http://nownownow.com/) movement. The purpose of this page is to share my current focus.

--- a/src/pages/uses.md
+++ b/src/pages/uses.md
@@ -5,8 +5,6 @@ description: A list of software and hardware that I use almost every day for sof
 permalink: /uses/
 headerImage: /images/banners/laptop.jpg
 date: 2020-01-30
-tags:
-    - post
 ---
 
 ## Hardware


### PR DESCRIPTION
## Changes

- Add author block
- Remove post tag from some pages
- Add now and uses pages to featured list

Some pages were previously tagged as `post` so that they would appear in the article list. Now that I've refactored the homepage, they can be added to the featured list and they'll appear on the first page.