### PR TITLE
feat: add accessible anchor links for h2 tags

### DIFF
--- a/_eleventy/markdown.js
+++ b/_eleventy/markdown.js
@@ -1,12 +1,59 @@
 const markdownIt = require('markdown-it');
 const markdownItAttributes = require('@gerhobbelt/markdown-it-attrs');
+const string = require('string');
 
 // Create own markdown renderer so we can add class attributes
 // https://www.11ty.dev/docs/languages/markdown/#markdown-options
 const markdownItOptions = {
     html: true,
 };
+
+const slugify = text => string(text).slugify().toString();
+
 const markdownLib = markdownIt(markdownItOptions);
-markdownLib.use(markdownItAttributes);
+
+const linkIcon = '<i class="fas fa-link fa-lg"></i>';
+
+// Render anchor links like GitHub
+const markdownAnchorLinks = (md, options) => {
+  const defaultOptions = {
+    divClass: 'group relative',
+    anchorClass: 'hidden lg:inline opacity-10 group-hover:opacity-100 absolute top-1 -left-10',
+  };
+
+  const anchorOptions = Object.assign({}, defaultOptions, options);
+
+  md.renderer.rules.heading_open = function(tokens, index) {
+    const contentToken = tokens[index + 1];
+    const slug = slugify(contentToken.content);
+
+    if (tokens[index].tag === 'h2') {
+      return `
+      <div class="${anchorOptions.divClass}">
+        <${tokens[index].tag} id="${slug}">`;
+    }
+    return `<${tokens[index].tag}>`;
+  };
+
+  md.renderer.rules.heading_close = function(tokens, index) {
+    const contentToken = tokens[index - 1];
+    const slug = slugify(contentToken.content);
+
+    if (tokens[index].tag === 'h2') {
+      return `
+      </${tokens[index].tag}>
+        <a class="${anchorOptions.anchorClass}" href="#${slug}">
+          <span aria-hidden="true">${linkIcon}</span>
+          <span class="hidden">Permalink to "${contentToken.content}"</span>
+        </a>
+      </div>`;
+    }
+    return `</${tokens[index].tag}>`;
+  };
+};
+
+markdownLib
+    .use(markdownItAttributes)
+    .use(markdownAnchorLinks);
 
 module.exports = markdownLib;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "postcss": "^8.2.10",
     "postcss-cli": "^8.3.1",
     "rfc822-date": "^0.0.3",
+    "string": "^3.3.3",
     "tailwindcss": "^2.0.4",
     "xml2js": "^0.4.23"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8706,6 +8706,11 @@ string.prototype.trimstart@^1.0.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
+string@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/string/-/string-3.3.3.tgz#5ea211cd92d228e184294990a6cc97b366a77cb0"
+  integrity sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA=
+
 string_decoder@^1.1.1, string_decoder@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"


### PR DESCRIPTION
## Changes

- Add markdown renderer for open and close tags to add an accessible anchor link
- Style links using Tailwind to display for large displays and to appear on hover

## Reference

[Are your anchor links accessible?](https://amberwilson.co.uk/blog/are-your-anchor-links-accessible/)