### PR TITLE
Fix incorrect slide includes

### DIFF
--- a/src/pages/talks/2017-04-25-securing-your-bbc-identity.md
+++ b/src/pages/talks/2017-04-25-securing-your-bbc-identity.md
@@ -17,6 +17,6 @@ We’ll look at how my team at the BBC approached security concerns when creatin
 
 ## Slides
 
-{% include partials/slideShareEmbed.html, slideShareId: {{slideShareId}} %}
+{% include partials/slideShareEmbed.html, slideShareId: slideShareId %}
 
 Location: [JavaScript North West Meetup](https://www.meetup.com/JavaScript-North-West/events/239152184/)

--- a/src/pages/talks/2017-07-04-7-tips-for-writing-great-unit-tests.md
+++ b/src/pages/talks/2017-07-04-7-tips-for-writing-great-unit-tests.md
@@ -14,7 +14,7 @@ How do you learn to write great unit tests? Why are some unit tests good and som
 
 ## Slides
 
-{% include partials/speakerDeckEmbed.html, speakerDeckId: {{speakerDeckId}} %}
+{% include partials/speakerDeckEmbed.html, speakerDeckId: speakerDeckId %}
 
 ## Video
 

--- a/src/pages/talks/2018-02-06-bbc-account-engineering-excellence-at-strictly-scale.md
+++ b/src/pages/talks/2018-02-06-bbc-account-engineering-excellence-at-strictly-scale.md
@@ -18,4 +18,4 @@ Here's a talk that I gave at BBC North's "Women In Tech" event in February 2018,
 
 ## Slides
 
-{% include partials/speakerDeckEmbed.html, speakerDeckId: {{speakerDeckId}} %}
+{% include partials/speakerDeckEmbed.html, speakerDeckId: speakerDeckId %}

--- a/src/pages/talks/2018-05-09-from-space-invaders-to-strictly.md
+++ b/src/pages/talks/2018-05-09-from-space-invaders-to-strictly.md
@@ -15,4 +15,4 @@ If you have any questions then get in [contact](/contact/) or tweet at me on [Tw
 
 ## Slides
 
-{% include partials/speakerDeckEmbed.html, speakerDeckId: {{speakerDeckId}} %}
+{% include partials/speakerDeckEmbed.html, speakerDeckId: speakerDeckId %}

--- a/src/pages/talks/2018-06-25-the-illest-man-in-the-hospital.md
+++ b/src/pages/talks/2018-06-25-the-illest-man-in-the-hospital.md
@@ -17,4 +17,4 @@ If you have any questions then get in [contact](/contact/) or tweet at me on [Tw
 
 ## Slides
 
-{% include partials/speakerDeckEmbed.html, speakerDeckId: {{speakerDeckId}} %}
+{% include partials/speakerDeckEmbed.html, speakerDeckId: speakerDeckId %}

--- a/src/pages/talks/2021-05-26-developing-an-inclusive-engineering-team.md
+++ b/src/pages/talks/2021-05-26-developing-an-inclusive-engineering-team.md
@@ -16,7 +16,7 @@ Enjoy!
 
 ## Slides
 
-{% include partials/speakerDeckEmbed.html, speakerDeckId: {{speakerDeckId}} %}
+{% include partials/speakerDeckEmbed.html, speakerDeckId: speakerDeckId %}
 
 ## Video
 


### PR DESCRIPTION
## Changes

- Update talk pages to ensure slides were rendered correctly.

## Why?

Updating to Eleventy 1.0 meant that frontmatter data isn't passed to included Liquid templates. I'd incorrectly escaped the frontmatter data as a parameter to the include tag so it was being passed as `true` to the embed files.