### PR TITLE
Set correct site URL for production deployment

### DIFF
--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -1,11 +1,12 @@
 const isDevelopmentBuild = process.env.ELEVENTY_ENV === 'dev';
+const isNetlifyProductionDeployment = process.env.CONTEXT === 'production';
 
 // Netlify build URL
-const buildUrl = process.env.DEPLOY_PRIME_URL ?
-  process.env.DEPLOY_PRIME_URL : 'https://www.marclittlemore.com';
+const netlifyBuildUrl = isNetlifyProductionDeployment ?
+  'https://www.marclittlemore.com' : process.env.DEPLOY_PRIME_URL;
 
 // Point to localhost URL for development builds
-const url = isDevelopmentBuild ? 'http://localhost:8080' : buildUrl;
+const url = isDevelopmentBuild ? 'http://localhost:8080' : netlifyBuildUrl;
 
 module.exports = {
   title: 'Marc Littlemore',


### PR DESCRIPTION
## Changes

- Check for Netlify production context to determine `site.url`

Previous PR #173 changed the `site.url` but for preview builds but didn't check whether the site was being deployed to production. This meant that the site domain became `https://main--marcl.netlify.app/` rather than the correct domain name. This PR should fix it.