### PR TITLE
fix: indie auth authentication

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -22,7 +22,10 @@ module.exports = (eleventyConfig) => {
     eleventyConfig.addPlugin(embedTwitter);
     eleventyConfig.addPlugin(timeToRead, {style: 'short'});
     eleventyConfig.addPlugin(tableOfContents);
-    eleventyConfig.addPlugin(externalLinks, {url: site.url});
+    eleventyConfig.addPlugin(externalLinks, {
+        url: site.url,
+        overwrite: false
+    });
 
     // Collections
     eleventyConfig.addCollection('tagList', (collection) => {

--- a/src/_includes/partials/footer.html
+++ b/src/_includes/partials/footer.html
@@ -26,7 +26,8 @@
                 href="{{ socialItem.url }}"
                 title="{{ socialItem.title }}"
                 class="block rounded-md flex-none"
-                aria-label="{{socialItem.name}} icon">
+                aria-label="{{socialItem.name}} icon"
+                rel="noreferrer nofollow noopener external me">
                 <i class="fa text-white hover:text-slate-500 {{socialItem.icon}} text-xl sm:text-3xl"></i>
               </a>
         {% endfor %}


### PR DESCRIPTION
## Summary

In #193, I refactored the footer and removed the `rel="me noreferer"` attribute as the external links were rewritten by the `eleventy-plugin-external-links` plugin. This means that the [IndieLogin](https://indielogin.com/) authentication broke as it no longer has `rel="me"`. This PR fixes the change and doesn't allow the plugin to overwrite the attributes for the social footer links.