### PR TITLE
fix: don't add google analytics for development build

### DIFF
--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -22,5 +22,6 @@ module.exports = {
   author: {
     name: 'Marc Littlemore',
     email: 'marc@marclittlemore.com'
-  }
+  },
+  isDevelopmentBuild
 };

--- a/src/_includes/partials/social/googleTracking.html
+++ b/src/_includes/partials/social/googleTracking.html
@@ -1,3 +1,4 @@
+{%- if site.isDevelopmentBuild != true -%}
 <script async src="https://www.googletagmanager.com/gtag/js?id={{site.googleAnalyticsId}}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -6,3 +7,6 @@
 
   gtag('config', '{{site.googleAnalyticsId}}');
 </script>
+{%- else -%}
+<!-- No Google analytics in development build -->
+{%- endif -%}


### PR DESCRIPTION
## Summary

- Remove Google analytics on development build