### PR TITLE
fix: make posts use h2 tag

### DIFF
--- a/src/_includes/partials/articles/standardCard.html
+++ b/src/_includes/partials/articles/standardCard.html
@@ -6,7 +6,7 @@
     </div>
     <div class="col-span-8 md:col-span-7">
         <a href="{{article.url}}" class="{{theme.article.text.hover}}">
-            <h5 class="text-2xl font-bold tracking-tight">{{article.data.title}}</h5>
+            <h2 class="text-2xl font-bold tracking-tight">{{article.data.title}}</h2>
         </a>
         {% render partials/articles/articleDate.html article:article theme:theme %}
         <p class="font-normal text-gray-700 dark:text-gray-400">{{article.data.description | markdownify}}</p>


### PR DESCRIPTION
## Summary

- Use h2 tags for post links